### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/rubocop-twirp.gemspec
+++ b/rubocop-twirp.gemspec
@@ -1,16 +1,19 @@
 require_relative "lib/rubocop/twirp/version"
-package = RuboCop::Twirp
-
 
 Gem::Specification.new do |s|
   s.authors     = ["Daniel Pepper"]
-  s.description = "..."
+  s.description = <<~DESCRIPTION
+    RuboCop cops for Twirp client code: flag deprecated positional
+    arguments to Twirp::ClientResp, encourage webmock-twirp stubs
+    over ad-hoc mocks, and steer expectations toward rspec-twirp
+    matchers.
+  DESCRIPTION
   s.files       = `git ls-files * ':!:spec'`.split("\n")
   s.homepage    = "https://github.com/dpep/rubocop-twirp"
   s.license     = "MIT"
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.summary     = package.to_s
-  s.version     = package.const_get "VERSION"
+  s.name        = "rubocop-twirp"
+  s.summary     = "RuboCop::Twirp"
+  s.version     = RuboCop::Twirp::VERSION
 
   s.required_ruby_version = ">= 3"
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "rubocop-twirp"
s.version = RuboCop::Twirp::VERSION
```


While here, replaced the previous `s.description` with a heredoc that actually describes what the gem does.

## Test plan

- [x] `Bundler.load_gemspec("rubocop-twirp.gemspec")` parses statically to name=`rubocop-twirp`, version=`0.1.0`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
